### PR TITLE
gpt: update the test case and fix the root partition UUID of LoongArch

### DIFF
--- a/src/shared/gpt.h
+++ b/src/shared/gpt.h
@@ -16,7 +16,7 @@
 #define GPT_ROOT_ARM         SD_ID128_MAKE(69,da,d7,10,2c,e4,4e,3c,b1,6c,21,a1,d4,9a,be,d3)
 #define GPT_ROOT_ARM_64      SD_ID128_MAKE(b9,21,b0,45,1d,f0,41,c3,af,44,4c,6f,28,0d,3f,ae)
 #define GPT_ROOT_IA64        SD_ID128_MAKE(99,3d,8d,3d,f8,0e,42,25,85,5a,9d,af,8e,d7,ea,97)
-#define GPT_ROOT_LOONGARCH64 SD_ID128_MAKE(77,05,58,00,79,2c,4f,94,b3,9a,99,c9,1b,76,2b,b6)
+#define GPT_ROOT_LOONGARCH64 SD_ID128_MAKE(77,05,58,00,79,2c,4f,94,b3,9a,98,c9,1b,76,2b,b6)
 #define GPT_ROOT_RISCV32     SD_ID128_MAKE(60,d5,a7,fe,8e,7d,43,5c,b7,14,3d,d8,16,21,44,e1)
 #define GPT_ROOT_RISCV64     SD_ID128_MAKE(72,ec,70,a6,cf,74,40,e6,bd,49,4b,da,08,e8,f2,24)
 #define GPT_USR_X86          SD_ID128_MAKE(75,25,0d,76,8c,c6,45,8e,bd,66,bd,47,cc,81,a8,12)

--- a/test/units/testsuite-50.sh
+++ b/test/units/testsuite-50.sh
@@ -97,6 +97,11 @@ elif [ "${machine}" = "ia64" ]; then
     verity_guid=86ed10d5-b607-45bb-8957-d350f23d0571
     signature_guid=e98b36ee-32ba-4882-9b12-0ce14655f46a
     architecture="ia64"
+elif [ "${machine}" = "loongarch64" ]; then
+    root_guid=77055800-792c-4f94-b39a-98c91b762bb6
+    verity_guid=f3393b22-e9af-4613-a948-9d3bfbd0c535
+    signature_guid=5afb67eb-ecc8-4f85-ae8e-ac1e7c50e7d0
+    architecture="loongarch64"
 elif [ "${machine}" = "ppc64le" ]; then
     # There's no support of PPC in the discoverable partitions specification yet, so skip the rest for now
     echo OK >/testok


### PR DESCRIPTION
第 2 个补丁，用于完善上游的 gpt 部分。